### PR TITLE
implement Discord authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,76 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# `discord-server-info`
 
-## Getting Started
+> Display information & statistics vital for managing a complex Discord server
+
+## Development
+
+### Installing packages
+
+This repository uses the [`pnpm`](https://pnpm.io/) package manager. See
+[Installation](https://pnpm.io/installation) for installation instructions.
+
+You can install this project's packages using `pnpm i`.
+
+### Configuring the application
+
+To run the app locally, you'll need to complete a few steps first:
+
+1. [Create a Discord Application in the Discord Developer Portal](https://blog.with-heart.xyz/creating-a-discord-application)
+2. On your application's page, go to the "OAuth2" page in the sidebar and add a
+   redirect to `http://localhost:3001/api/auth/callback/discord`
+3. [Store your application's client ID and secret in `.env.local`](https://blog.with-heart.xyz/storing-and-accessing-discord-application-environment-variables-with-nextjs)
+
+### Starting the application
+
+```
+pnpm run dev
+```
+
+## Next.js
+
+This is a [Next.js](https://nextjs.org/) project bootstrapped with
+[`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+
+### Getting Started
 
 First, run the development server:
 
 ```bash
-npm run dev
-# or
-yarn dev
+pnpm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the
+result.
 
-You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+You can start editing the page by modifying `pages/index.tsx`. The page
+auto-updates as you edit the file.
 
-[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.ts`.
+[API routes](https://nextjs.org/docs/api-routes/introduction) can be accessed on
+[http://localhost:3000/api/hello](http://localhost:3000/api/hello). This
+endpoint can be edited in `pages/api/hello.ts`.
 
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead of React pages.
+The `pages/api` directory is mapped to `/api/*`. Files in this directory are
+treated as [API routes](https://nextjs.org/docs/api-routes/introduction) instead
+of React pages.
 
-## Learn More
+### Learn More
 
 To learn more about Next.js, take a look at the following resources:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
+- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js
+  features and API.
 - [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+You can check out
+[the Next.js GitHub repository](https://github.com/vercel/next.js/) - your
+feedback and contributions are welcome!
 
-## Deploy on Vercel
+### Deploy on Vercel
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+The easiest way to deploy your Next.js app is to use the
+[Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme)
+from the creators of Next.js.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+Check out our
+[Next.js deployment documentation](https://nextjs.org/docs/deployment) for more
+details.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "next": "12.1.6",
+    "next-auth": "^4.3.4",
     "react": "18.1.0",
     "react-dom": "18.1.0"
   },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,7 +1,12 @@
+import {SessionProvider} from 'next-auth/react'
 import type {AppProps} from 'next/app'
 
-function MyApp({Component, pageProps}: AppProps) {
-  return <Component {...pageProps} />
+function MyApp({Component, pageProps: {session, ...pageProps}}: AppProps) {
+  return (
+    <SessionProvider session={session}>
+      <Component {...pageProps} />
+    </SessionProvider>
+  )
 }
 
 export default MyApp

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,4 +1,5 @@
 import NextAuth from 'next-auth'
+import {JWT} from 'next-auth/jwt'
 import DiscordProvider from 'next-auth/providers/discord'
 
 const scopes = ['identify'].join(' ')
@@ -33,15 +34,62 @@ export default NextAuth({
         }
       }
 
-      return token
+      // return existing token because it's not expired
+      if (Date.now() < (token.accessTokenExpires as number)) {
+        return token
+      }
+
+      // token expired so try to refresh it
+      return refreshDiscordToken(token)
     },
     session({session, token}) {
       // @ts-expect-error
       session.user = token.user
-      session.accessToken = token.accessToken
-      session.error = token.error
+      session.accessToken = token.accessToken as string
+      session.error = token.error as string | undefined
 
       return session
     },
   },
 })
+
+async function refreshDiscordToken(token: JWT) {
+  try {
+    const url = 'https://discord.com/api/oauth2/token'
+    const body = new URLSearchParams({
+      client_id: process.env.DISCORD_CLIENT_ID!,
+      client_secret: process.env.DISCORD_CLIENT_SECRET!,
+      grant_type: 'refresh_token',
+      refresh_token: token.refreshToken as string,
+    }).toString()
+
+    const response = await fetch(url, {
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body,
+      method: 'POST',
+    })
+
+    const refreshedTokens = await response.json()
+
+    if (!response.ok) {
+      throw refreshedTokens
+    }
+
+    return {
+      ...token,
+      accessToken: refreshedTokens.access_token,
+      accessTokenExpires:
+        Date.now() + (refreshedTokens.expires_in as number) * 1000,
+      refreshToken: refreshedTokens.refresh_token ?? token.refreshToken,
+    }
+  } catch (error) {
+    console.error(error)
+
+    return {
+      ...token,
+      error: 'RefreshAccessTokenError',
+    }
+  }
+}

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -21,4 +21,27 @@ export default NextAuth({
       authorization: {params: {scope: scopes}},
     }),
   ],
+  callbacks: {
+    async jwt({token, account, user}) {
+      // initial sign in
+      if (account && user) {
+        return {
+          accessToken: account.access_token,
+          accessTokenExpires: account.expires_at! * 1000,
+          refreshToken: account.refresh_token,
+          user,
+        }
+      }
+
+      return token
+    },
+    session({session, token}) {
+      // @ts-expect-error
+      session.user = token.user
+      session.accessToken = token.accessToken
+      session.error = token.error
+
+      return session
+    },
+  },
 })

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,0 +1,24 @@
+import NextAuth from 'next-auth'
+import DiscordProvider from 'next-auth/providers/discord'
+
+const scopes = ['identify'].join(' ')
+
+const {DISCORD_CLIENT_ID, DISCORD_CLIENT_SECRET} = process.env
+
+if (!DISCORD_CLIENT_ID) {
+  throw Error('DISCORD_CLIENT_ID is not set')
+}
+
+if (!DISCORD_CLIENT_SECRET) {
+  throw Error('DISCORD_CLIENT_SECRET is not set')
+}
+
+export default NextAuth({
+  providers: [
+    DiscordProvider({
+      clientId: process.env.DISCORD_CLIENT_ID!,
+      clientSecret: process.env.DISCORD_CLIENT_SECRET!,
+      authorization: {params: {scope: scopes}},
+    }),
+  ],
+})

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,22 +1,53 @@
 import type {NextPage} from 'next'
-import Head from 'next/head'
+import {signIn, signOut, useSession} from 'next-auth/react'
+import NextHead from 'next/head'
+import {ReactNode} from 'react'
+
+const Container = ({children}: {children: ReactNode}) => (
+  <div>
+    <NextHead>
+      <title>discord-server-info</title>
+      <meta
+        name="description"
+        content="Display information &amp; statistics vital for managing a complex Discord server"
+      />
+      <link rel="icon" href="/favicon.ico" />
+    </NextHead>
+
+    <main>
+      <h1>discord-server-info</h1>
+
+      {children}
+    </main>
+  </div>
+)
 
 const Home: NextPage = () => {
-  return (
-    <div>
-      <Head>
-        <title>discord-server-info</title>
-        <meta
-          name="description"
-          content="Display information &amp; statistics vital for managing a complex Discord server"
-        />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
+  const {data: session} = useSession()
 
-      <main>
-        <h1>discord-server-info</h1>
-      </main>
-    </div>
+  if (session) {
+    const {user} = session
+
+    return (
+      <Container>
+        <div>
+          <p>
+            Welcome{user && user.name ? ` ${user.name}` : null}! You&apos;re
+            signed in!
+          </p>
+          <button onClick={() => signOut()}>Sign out</button>
+        </div>
+      </Container>
+    )
+  }
+
+  return (
+    <Container>
+      <div>
+        You&apos;re not signed in.
+        <button onClick={() => signIn('discord')}>Sign in with Discord</button>
+      </div>
+    </Container>
   )
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,12 +7,14 @@ specifiers:
   eslint: 8.15.0
   eslint-config-next: 12.1.6
   next: 12.1.6
+  next-auth: ^4.3.4
   react: 18.1.0
   react-dom: 18.1.0
   typescript: 4.6.4
 
 dependencies:
   next: 12.1.6_ef5jwxihqo6n7gxfmzogljlgcm
+  next-auth: 4.3.4_ef5jwxihqo6n7gxfmzogljlgcm
   react: 18.1.0
   react-dom: 18.1.0_react@18.1.0
 
@@ -39,7 +41,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.9
-    dev: true
 
   /@eslint/eslintrc/1.2.3:
     resolution: {integrity: sha512-uGo44hIwoLGNyduRpjdEpovcbMdd+Nv7amtmJxnKmI8xj6yd5LncmSwDa5NgX/41lIFJtkjD6YdVfgEzPfJ5UA==}
@@ -211,6 +212,10 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
     dev: true
+
+  /@panva/hkdf/1.0.2:
+    resolution: {integrity: sha512-MSAs9t3Go7GUkMhpKC44T58DJ5KGk2vBo+h1cqQeqlMfdGkxaVB78ZWpv9gYi/g2fa4sopag9gJsNvS8XGgWJA==}
+    dev: false
 
   /@rushstack/eslint-patch/1.1.3:
     resolution: {integrity: sha512-WiBSI6JBIhC6LRIsB2Kwh8DsGTlbBU+mLRxJmAe3LjHTdkDpwIbEOZgoXBbZilk/vlfjK8i6nKRAvIRn1XaIMw==}
@@ -460,6 +465,11 @@ packages:
   /concat-map/0.0.1:
     resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: true
+
+  /cookie/0.4.2:
+    resolution: {integrity: sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==}
+    engines: {node: '>= 0.6'}
+    dev: false
 
   /core-js-pure/3.22.5:
     resolution: {integrity: sha512-8xo9R00iYD7TcV7OrC98GwxiUEAabVWO3dix+uyWjnYrx9fyASLlIX+f/3p5dW5qByaP2bcZ8X/T47s55et/tA==}
@@ -1203,6 +1213,10 @@ packages:
     resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
     dev: true
 
+  /jose/4.8.1:
+    resolution: {integrity: sha512-+/hpTbRcCw9YC0TOfN1W47pej4a9lRmltdOVdRLz5FP5UvUq3CenhXjQK7u/8NdMIIShMXYAh9VLPhc7TjhvFw==}
+    dev: false
+
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1277,7 +1291,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: true
 
   /merge2/1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -1324,6 +1337,30 @@ packages:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
     dev: true
 
+  /next-auth/4.3.4_ef5jwxihqo6n7gxfmzogljlgcm:
+    resolution: {integrity: sha512-8dGkNicbxY2BYsJq4uOJIEsGt39wXj5AViTBsVfbRQqtAFmZmXYHutf90VBmobm8rT2+Xl60HDUTkuVVK+x+xw==}
+    engines: {node: ^12.19.0 || ^14.15.0 || ^16.13.0}
+    peerDependencies:
+      nodemailer: ^6.6.5
+      react: ^17.0.2 || ^18
+      react-dom: ^17.0.2 || ^18
+    peerDependenciesMeta:
+      nodemailer:
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.17.9
+      '@panva/hkdf': 1.0.2
+      cookie: 0.4.2
+      jose: 4.8.1
+      oauth: 0.9.15
+      openid-client: 5.1.6
+      preact: 10.7.2
+      preact-render-to-string: 5.2.0_preact@10.7.2
+      react: 18.1.0
+      react-dom: 18.1.0_react@18.1.0
+      uuid: 8.3.2
+    dev: false
+
   /next/12.1.6_ef5jwxihqo6n7gxfmzogljlgcm:
     resolution: {integrity: sha512-cebwKxL3/DhNKfg9tPZDQmbRKjueqykHHbgaoG4VBRH3AHQJ2HO0dbKFiS1hPhe1/qgc2d/hFeadsbPicmLD+A==}
     engines: {node: '>=12.22.0'}
@@ -1366,10 +1403,19 @@ packages:
       - babel-plugin-macros
     dev: false
 
+  /oauth/0.9.15:
+    resolution: {integrity: sha1-vR/vr2hslrdUda7VGWQS/2DPucE=}
+    dev: false
+
   /object-assign/4.1.1:
     resolution: {integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /object-hash/2.2.0:
+    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
+    engines: {node: '>= 6'}
+    dev: false
 
   /object-inspect/1.12.0:
     resolution: {integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==}
@@ -1424,11 +1470,26 @@ packages:
       es-abstract: 1.20.1
     dev: true
 
+  /oidc-token-hash/5.0.1:
+    resolution: {integrity: sha512-EvoOtz6FIEBzE+9q253HsLCVRiK/0doEJ2HCvvqMQb3dHZrP3WlJKYtJ55CRTw4jmYomzH4wkPuCj/I3ZvpKxQ==}
+    engines: {node: ^10.13.0 || >=12.0.0}
+    dev: false
+
   /once/1.4.0:
     resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
     dependencies:
       wrappy: 1.0.2
     dev: true
+
+  /openid-client/5.1.6:
+    resolution: {integrity: sha512-HTFaXWdUHvLFw4GaEMgC0jXYBgpjgzQQNHW1pZsSqJorSgrXzxJ+4u/LWCGaClDEse5HLjXRV+zU5Bn3OefiZw==}
+    engines: {node: ^12.19.0 || ^14.15.0 || ^16.13.0}
+    dependencies:
+      jose: 4.8.1
+      lru-cache: 6.0.0
+      object-hash: 2.2.0
+      oidc-token-hash: 5.0.1
+    dev: false
 
   /optionator/0.9.1:
     resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
@@ -1510,10 +1571,27 @@ packages:
       source-map-js: 1.0.2
     dev: false
 
+  /preact-render-to-string/5.2.0_preact@10.7.2:
+    resolution: {integrity: sha512-+RGwSW78Cl+NsZRUbFW1MGB++didsfqRk+IyRVTaqy+3OjtpKK/6HgBtfszUX0YXMfo41k2iaQSseAHGKEwrbg==}
+    peerDependencies:
+      preact: '>=10'
+    dependencies:
+      preact: 10.7.2
+      pretty-format: 3.8.0
+    dev: false
+
+  /preact/10.7.2:
+    resolution: {integrity: sha512-GLjn0I3r6ka+NvxJUppsVFqb4V0qDTEHT/QxHlidPuClGaxF/4AI2Qti4a0cv3XMh5n1+D3hLScW10LRIm5msQ==}
+    dev: false
+
   /prelude-ls/1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
     dev: true
+
+  /pretty-format/3.8.0:
+    resolution: {integrity: sha1-v77VbV6ad2ZF9LH/eqGjrE+jw4U=}
+    dev: false
 
   /prop-types/15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -1555,7 +1633,6 @@ packages:
 
   /regenerator-runtime/0.13.9:
     resolution: {integrity: sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==}
-    dev: true
 
   /regexp.prototype.flags/1.4.3:
     resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
@@ -1800,6 +1877,11 @@ packages:
       punycode: 2.1.1
     dev: true
 
+  /uuid/8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+    dev: false
+
   /v8-compile-cache/2.3.0:
     resolution: {integrity: sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==}
     dev: true
@@ -1833,4 +1915,3 @@ packages:
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,10 @@
+import NextAuth, {DefaultSession} from 'next-auth'
+import {JWT} from 'next-auth/jwt'
+
+declare module 'next-auth' {
+  interface Session {
+    user: DefaultSession['user']
+    accessToken: string
+    error?: string
+  }
+}


### PR DESCRIPTION
This PR closes #5 by making a few changes:

- installed & configured [`next-auth`](https://next-auth.js.org/)
- added [`DiscordProvider`](https://next-auth.js.org/providers/discord) connected to client secrets and the `identify` scope
- enabled expired access token refresh
- made `accessToken` and `error` available through `useSession`/`getSession`
  - added [module augmentation](https://next-auth.js.org/getting-started/typescript#module-augmentation) so change is reflected at the types layer
- added local dev notes so anyone can run this locally